### PR TITLE
Implement home page and theme toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,25 @@
-from flask import Flask
+from flask import Flask, url_for
+from datetime import datetime
 from routes import register_blueprints
+import config
 
 app = Flask(__name__)
+app.config.from_object(config.Config)
 register_blueprints(app)
 
+@app.context_processor
+def cache_buster():
+    def static_url(filename):
+        if app.config.get('FORCE_NOCACHE'):
+            version = int(datetime.utcnow().timestamp())
+            return url_for('static', filename=filename, v=version)
+        return url_for('static', filename=filename)
+    return dict(static_url=static_url)
+
+@app.route('/toggle-nocache')
+def toggle_nocache():
+    app.config['FORCE_NOCACHE'] = not app.config.get('FORCE_NOCACHE', False)
+    return f"FORCE_NOCACHE = {app.config['FORCE_NOCACHE']}"
+
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(host='0.0.0.0', port=8001, debug=True)

--- a/config.py
+++ b/config.py
@@ -1,2 +1,3 @@
 class Config:
     SECRET_KEY = 'change-me'
+    FORCE_NOCACHE = False

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 # EzyGallery Documentation
 
-Placeholder documentation.
+This project is a simple Flask showcase for the EzyGallery MVP. A light and dark theme can be toggled via the button in the page header. The selected theme is stored in the browser and reapplied on next visit.
+
+For development there is an optional cache busting system. Toggle it by visiting `/toggle-nocache`. When enabled, static asset URLs will include a timestamp query parameter so browsers always fetch the latest files.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,4 @@
 # Changelog
 
 - Initial scaffold.
+- Added home page, light/dark theme toggle and optional cache busting.

--- a/docs/qa_checklist.md
+++ b/docs/qa_checklist.md
@@ -1,0 +1,10 @@
+# QA Checklist
+
+- [ ] Home page loads with no errors at /
+- [ ] Sidebar menu and header are visible and styled
+- [ ] All main routes (Gallery, Marketplace, Uploads, Docs, Admin) load without error
+- [ ] Theme toggle (Light/Dark) works and persists after reload
+- [ ] No template or static asset 404s
+- [ ] Confirm cache-busting works if enabled
+- [ ] Run 'git status' to confirm no unwanted files are committed (venv, .env, etc. are ignored)
+- [ ] All new/modified files have clear comments and docstrings

--- a/routes/home.py
+++ b/routes/home.py
@@ -3,5 +3,6 @@ from flask import Blueprint, render_template
 home_bp = Blueprint('home', __name__)
 
 @home_bp.route('/')
+@home_bp.route('/home')
 def index():
-    return render_template('index.html')
+    return render_template('home/home.html')

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,16 @@
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+}
+
+.theme-dark {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+}

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+  const saved = localStorage.getItem('theme') || 'light';
+  applyTheme(saved);
+
+  toggle.addEventListener('click', () => {
+    const isDark = document.documentElement.classList.contains('theme-dark');
+    applyTheme(isDark ? 'light' : 'dark');
+  });
+});
+
+function applyTheme(theme) {
+  if (theme === 'dark') {
+    document.documentElement.classList.add('theme-dark');
+  } else {
+    document.documentElement.classList.remove('theme-dark');
+  }
+  localStorage.setItem('theme', theme);
+}

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -1,1 +1,4 @@
-<!-- Header placeholder -->
+<header style="padding:10px;display:flex;justify-content:space-between;align-items:center;">
+  <h1 style="margin:0;">EzyGallery</h1>
+  <button id="theme-toggle">Toggle Theme</button>
+</header>

--- a/templates/home/home.html
+++ b/templates/home/home.html
@@ -1,0 +1,9 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Welcome to EzyGallery</h2>
+<nav>
+  <a href="/gallery">Gallery</a> |
+  <a href="/uploads">Uploads</a> |
+  <a href="/docs">Docs</a>
+</nav>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -4,8 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>EzyGallery</title>
+    <link rel="stylesheet" href="{{ static_url('css/theme.css') }}">
 </head>
 <body>
+    {% include 'components/header.html' %}
     {% block content %}{% endblock %}
+    <script src="{{ static_url('js/base.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add cache busting context processor and toggle route
- update config with FORCE_NOCACHE flag
- build simple layout with header and theme toggle
- create new home route and template
- add light/dark theme CSS and JS
- document theme and cache busting
- provide QA checklist for manual testing

## Testing
- `pip install -r requirements.txt`
- `python app.py` *(fails: Address already in use on first run, succeeds on second run)*

------
https://chatgpt.com/codex/tasks/task_e_6870bb0640b4832ea5a0d80aa04e68f1