### PR TITLE
Add home page and navigation header

### DIFF
--- a/routes/home.py
+++ b/routes/home.py
@@ -5,4 +5,5 @@ home_bp = Blueprint('home', __name__)
 @home_bp.route('/')
 @home_bp.route('/home')
 def index():
-    return render_template('home/home.html')
+    """Display the main home page."""
+    return render_template('home.html')

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -180,3 +180,22 @@ button {
     justify-content: center;
   }
 }
+
+/* ------------------------------------------------------------
+   Home hero
+   --------------------------------------------------------- */
+.hero {
+  padding: 4rem 0;
+  text-align: center;
+}
+.hero .btn {
+  margin-top: var(--space-3);
+}
+
+/* Header flex container */
+.flex-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--menu-height);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,16 +10,16 @@
 </head>
 <body data-theme="light">
   <header class="site-header">
-    <div class="logo-row">
+    <div class="container flex-header">
       <a href="{{ url_for('home.index') }}" class="logo-text">EZY <span>gallery</span></a>
+      <nav class="nav-row">
+        <ul class="nav-list">
+          {% for page in available_pages %}
+            <li><a href="{{ page.url }}" class="{% if request.path == page.url %}active{% endif %}">{{ page.name }}</a></li>
+          {% endfor %}
+        </ul>
+      </nav>
     </div>
-    <nav class="nav-row">
-      <ul class="nav-list">
-        {% for page in available_pages %}
-          <li><a href="{{ page.url }}" class="{% if request.path == page.url %}active{% endif %}">{{ page.name }}</a></li>
-        {% endfor %}
-      </ul>
-    </nav>
   </header>
 
   <main class="container">

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,6 +1,11 @@
 {% extends 'base.html' %}
 {% block title %}Home - EzyGallery{% endblock %}
 {% block content %}
-<h2>Welcome to EzyGallery</h2>
-<p>This is the home page.</p>
+<section class="hero">
+  <div class="container">
+    <h1>EzyGallery</h1>
+    <p>Discover unique art prints for your space.</p>
+    <a href="{{ url_for('gallery.gallery') }}" class="btn">Browse Gallery</a>
+  </div>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create a new homepage
- add navigation header that links to available pages
- tweak styling for hero section and header layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872664d2b74832ea3dbb0bb369408cf