### PR TITLE
Add EzyGallery static content pages

### DIFF
--- a/static/img/placeholder.jpg
+++ b/static/img/placeholder.jpg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Image</text>
+</svg>

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,5 +1,34 @@
-{% extends "base.html" %}
+{% extends 'layout.html' %}
+{% block title %}About EzyGallery{% endblock %}
 {% block content %}
-<h1>About</h1>
-<p>Coming soon...</p>
+<section class="container mx-auto p-6 space-y-6">
+  <h1 class="text-3xl font-bold mb-4">About EzyGallery</h1>
+  <p>
+    Born from the creative drive of Robbie Custance, an Aboriginal artist who
+    turned digital to share culture with the world, EzyGallery mixes art and
+    automation so every artist can shine.
+  </p>
+  <p>
+    What started as a few mockups on a dusty laptop is now a platform powering
+    uploads, AI listings and exports to places like Sellbrite. The goal? Help
+    artists tell their stories and keep their voice strong—without selling out
+    or drowning in admin.
+  </p>
+  <img src="{{ static_url('img/placeholder.jpg') }}" alt="Artwork placeholder"
+       class="w-full rounded shadow">
+  <blockquote class="border-l-4 pl-4 italic">
+    "Tech moves fast, but culture runs deep. We reckon both can work together."
+  </blockquote>
+  <p>
+    With a focus on ethical scale and smart automation, we weave
+    art-tech fusion that keeps creativity front and centre.
+  </p>
+</section>
+<footer class="container mx-auto p-6 text-center space-x-4">
+  <a href="{{ url_for('flatpage', page_name='index') }}">Back to Home</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='upload') }}">Upload</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='gallery') }}">Gallery</a>
+</footer>
 {% endblock %}

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -1,5 +1,40 @@
-{% extends "base.html" %}
+{% extends 'layout.html' %}
+{% block title %}Artwork Gallery{% endblock %}
 {% block content %}
-<h1>Gallery</h1>
-<p>Coming soon...</p>
+<section class="container mx-auto p-6">
+  <h1 class="text-3xl font-bold mb-6">Artwork Gallery</h1>
+  <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+    {% set titles = [
+      'Wattle Dreaming',
+      'Ocean Eyes',
+      'Tracks of Fire',
+      'Desert Whispers',
+      'Rain Song',
+      'Midnight Gum',
+      'Coastal Flow',
+      'Sunlit Path',
+      'Earth Echo'
+    ] %}
+    {% for title in titles[:9] %}
+    <figure class="relative group bg-gray-100 rounded shadow overflow-hidden">
+      <img src="{{ static_url('img/placeholder.jpg') }}" alt="{{ title }}"
+           class="w-full h-auto">
+      <figcaption class="absolute inset-0 flex flex-col items-center justify-center bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 transition">
+        <h3 class="text-white mb-2">{{ title }}</h3>
+        <div class="space-x-2">
+          <a href="#" class="px-2 py-1 bg-white text-sm">View Details</a>
+          <a href="#" class="px-2 py-1 bg-white text-sm">Add to Export</a>
+        </div>
+      </figcaption>
+    </figure>
+    {% endfor %}
+  </div>
+</section>
+<footer class="container mx-auto p-6 text-center space-x-4">
+  <a href="{{ url_for('flatpage', page_name='index') }}">Back to Home</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='upload') }}">Upload</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='about') }}">About</a>
+</footer>
 {% endblock %}

--- a/templates/intro.html
+++ b/templates/intro.html
@@ -1,0 +1,28 @@
+{% extends 'layout.html' %}
+{% block title %}Welcome to EzyGallery{% endblock %}
+{% block content %}
+<section class="container mx-auto p-6 space-y-6 text-center">
+  <h1 class="text-4xl font-bold mb-4">Your Story. Your Art. Your Gallery.</h1>
+  <p>
+    Aboriginal Australian art meets next-gen automation here at EzyGallery.
+    We blend culture with clever tech so you can focus on creating.
+  </p>
+  <ul class="list-disc list-inside text-left max-w-xl mx-auto">
+    <li>Upload once, store forever</li>
+    <li>AI-crafted listings ready for the web</li>
+    <li>Mockups sorted by room and vibe</li>
+    <li>Export straight to your favourite marketplaces</li>
+  </ul>
+  <div class="space-x-4 mt-4">
+    <a href="{{ url_for('flatpage', page_name='upload') }}" class="px-4 py-2 bg-blue-600 text-white rounded">Upload</a>
+    <a href="{{ url_for('flatpage', page_name='gallery') }}" class="px-4 py-2 bg-green-600 text-white rounded">Gallery</a>
+  </div>
+</section>
+<footer class="container mx-auto p-6 text-center space-x-4">
+  <a href="{{ url_for('flatpage', page_name='index') }}">Back to Home</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='about') }}">About</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='privacy') }}">Privacy Policy</a>
+</footer>
+{% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,24 @@
+{% extends 'layout.html' %}
+{% block title %}Privacy Policy{% endblock %}
+{% block content %}
+<section class="container mx-auto p-6 space-y-6">
+  <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
+  <p>
+    We keep things simple: no sneaky tracking beyond what helps the site run.
+    Anything you upload stays private until you choose to share it.
+  </p>
+  <p>
+    We do lean on a few mates like OpenAI and Sellbrite to power our tools,
+    so your data may pass through their services—but only to make your life
+    easier here on EzyGallery.
+  </p>
+  <p>Got questions? Email us at <a href="mailto:privacy@ezygallery.com">privacy@ezygallery.com</a>.</p>
+</section>
+<footer class="container mx-auto p-6 text-center space-x-4">
+  <a href="{{ url_for('flatpage', page_name='index') }}">Back to Home</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='upload') }}">Upload</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='gallery') }}">Gallery</a>
+</footer>
+{% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,0 +1,27 @@
+{% extends 'layout.html' %}
+{% block title %}Terms & Conditions{% endblock %}
+{% block content %}
+<section class="container mx-auto p-6 space-y-6">
+  <h1 class="text-3xl font-bold mb-4">Terms &amp; Conditions</h1>
+  <p>
+    All artwork here is digital and protected by copyright. Mate, don’t steal
+    stuff, and we won’t either. Each listing you purchase grants you a licence
+    for personal or exclusive use as noted.
+  </p>
+  <p>
+    We offer limited editions for certain pieces. Listings are capped at
+    500 characters so you know exactly what you’re getting.
+  </p>
+  <p>
+    By using this site you agree to follow these terms and respect the artists
+    who share their stories here.
+  </p>
+</section>
+<footer class="container mx-auto p-6 text-center space-x-4">
+  <a href="{{ url_for('flatpage', page_name='index') }}">Back to Home</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='upload') }}">Upload</a>
+  <span>|</span>
+  <a href="{{ url_for('flatpage', page_name='gallery') }}">Gallery</a>
+</footer>
+{% endblock %}


### PR DESCRIPTION
## Summary
- flesh out `about.html` with origin story and mission
- add a starter `gallery.html` grid with placeholder artwork
- include privacy and terms pages
- add an intro page with a warm welcome and feature list
- add placeholder image for static pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737541732c832eba3275cfe9b88ce7